### PR TITLE
Use namespaces, better module loading and Soil unloading

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -1,27 +1,41 @@
 <?php
 
+namespace Sageextras\Nav;
 /**
- * Restore the Roots 7.0.3 Bootstrap Navwalker for a cleaner Bootstrap menu 
+ * Restore the Roots 7.0.3 Bootstrap Navwalker for a cleaner Bootstrap menu
+ *  
+ * * Walker_Nav_Menu (WordPress default) example output:
+ *   <li id="menu-item-8" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8"><a href="/">Home</a></li>
+ *   <li id="menu-item-9" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9"><a href="/sample-page/">Sample Page</a></l
+ *
+ * Sageextras_Nav_Walker example output:
+ *   <li class="menu-home"><a href="/">Home</a></li>
+ *   <li class="menu-sample-page"><a href="/sample-page/">Sample Page</a></li>
  */
-class Sagextras_Nav_Walker extends Walker_Nav_Menu {
+class NavWalker extends \Walker_Nav_Menu {
   private $cpt; // Boolean, is current post a custom post type.
   private $archive; // Stores the archive page for current url.
-  function __construct() {
+  
+  public function __construct() {
     add_filter('nav_menu_css_class', array($this, 'css_classes'), 10, 2);
     add_filter('nav_menu_item_id', '__return_null');
     $cpt           = get_post_type();
     $this->cpt     = in_array($cpt, get_post_types(array('_builtin' => false)));
     $this->archive = get_post_type_archive_link($cpt);
   }
+  
   function check_current($classes) {
     return preg_match('/(current[-_])|active|dropdown/', $classes);
   }
+  
   function start_lvl(&$output, $depth = 0, $args = array()) {
     $output .= "\n<ul class=\"dropdown-menu\">\n";
   }
+  
   function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0) {
     $item_html = '';
     parent::start_el($item_html, $item, $depth, $args);
+    
     if ($item->is_dropdown && ($depth === 0)) {
       $item_html = str_replace('<a', '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"', $item_html);
       $item_html = str_replace('</a>', ' <b class="caret"></b></a>', $item_html);
@@ -32,38 +46,51 @@ class Sagextras_Nav_Walker extends Walker_Nav_Menu {
     elseif (stristr($item_html, 'li class="dropdown-header')) {
       $item_html = preg_replace('/<a[^>]*>(.*)<\/a>/iU', '$1', $item_html);
     }
+    
     $item_html = apply_filters('sagextras_wp_nav_menu_item', $item_html);
     $output .= $item_html;
   }
+  
   function display_element($element, &$children_elements, $max_depth, $depth = 0, $args, &$output) {
     $element->is_dropdown = ((!empty($children_elements[$element->ID]) && (($depth + 1) < $max_depth || ($max_depth === 0))));
+    
     if ($element->is_dropdown) {
       $element->classes[] = 'dropdown';
+      
       foreach ($children_elements[$element->ID] as $child) {
         if ($child->current_item_parent || url_compare($this->archive, $child->url)) {
           $element->classes[] = 'active';
         }
       }
     }
+    
     $element->is_active = strpos($this->archive, $element->url);
+    
     if ($element->is_active) {
       $element->classes[] = 'active';
     }
+    
     parent::display_element($element, $children_elements, $max_depth, $depth, $args, $output);
   }
   public function css_classes($classes, $item) {
     $slug = sanitize_title($item->title);
+    
     if ($this->cpt) {
       $classes = str_replace('current_page_parent', '', $classes);
+      
       if (url_compare($this->archive, $item->url)) {
         $classes[] = 'active';
       }
     }
+    
     $classes = preg_replace('/(current(-menu-|[-_]page[-_])(item|parent|ancestor))/', 'active', $classes);
     $classes = preg_replace('/^((menu|page)[-_\w+]+)+/', '', $classes);
+    
     $classes[] = 'menu-' . $slug;
+   
     $classes = array_unique($classes);
-    return array_filter($classes, 'is_element_empty');
+    
+    return array_filter($classes, 'Sageextras\\Nav\\is_element_empty');
   }
 }
 
@@ -71,10 +98,10 @@ class Sagextras_Nav_Walker extends Walker_Nav_Menu {
  * Clean up wp_nav_menu_args
  *
  * Remove the container
- * Use Sagextras_Nav_Walker() by default
+ * Use Sagextras\Nav\NavWalker() by default
  * Remove the id="" on nav menu items
  */
-function sagextras_nav_menu_args($args = '') {
+function nav_menu_args($args = '') {
   $sagextras_nav_menu_args['container'] = false;
   if (!$args['items_wrap']) {
     $sagextras_nav_menu_args['items_wrap'] = '<ul class="%2$s">%3$s</ul>';
@@ -83,7 +110,7 @@ function sagextras_nav_menu_args($args = '') {
     $sagextras_nav_menu_args['depth'] = 2;
   }
   if (!$args['walker']) {
-    $sagextras_nav_menu_args['walker'] = new Sagextras_Nav_Walker();
+    $sagextras_nav_menu_args['walker'] = new NavWalker();
   }
   return array_merge($args, $sagextras_nav_menu_args);
 }
@@ -96,15 +123,39 @@ function is_element_empty($element) {
   return !empty($element);
 }
 
+/**
+ * Make a URL relative
+ */
+function root_relative_url($input) {
+  $url = parse_url($input);
+  if (!isset($url['host']) || !isset($url['path'])) {
+    return $input;
+  }
+  $site_url = parse_url(network_site_url());  // falls back to site_url
+
+  if (!isset($url['scheme'])) {
+    $url['scheme'] = $site_url['scheme'];
+  }
+  $hosts_match = $site_url['host'] === $url['host'];
+  $schemes_match = $site_url['scheme'] === $url['scheme'];
+  $ports_exist = isset($site_url['port']) && isset($url['port']);
+  $ports_match = ($ports_exist) ? $site_url['port'] === $url['port'] : true;
+
+  if ($hosts_match && $schemes_match && $ports_match) {
+    return wp_make_link_relative($input);
+  }
+  return $input;
+}
+
 function url_compare($url, $rel) {
   $url = trailingslashit($url);
   $rel = trailingslashit($rel);
-  if ((strcasecmp($url, $rel) === 0) || sagextras_root_relative_url($url) == $rel) { 
+  if ((strcasecmp($url, $rel) === 0) || root_relative_url($url) == $rel) { 
     return true; 
   } else {
     return false;
   }
 }
 
-add_filter('wp_nav_menu_args', 'sagextras_nav_menu_args');
+add_filter('wp_nav_menu_args', __NAMESPACE__ .'\\nav_menu_args');
 add_filter('nav_menu_item_id', '__return_null');


### PR DESCRIPTION
This Pull request is rather big but with small changes:
- Change navwalker to nav-walker so that it's in line with Soil
- Start using Namespaces
- Load modules dynamically, based on filename
- If theme supports Soil feature and same feature in Sagextras - unset support for soil feature.
- Add more content in comment to be in line with Soil
- More whitespace for code readability

I've tested it on my beta site and nothing expoded in my face, so I guess it's good enough for now :smile:
