### PR TITLE
Turn is_element_emty into closure, per roots/soil #95

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -91,7 +91,10 @@ class NavWalker extends \Walker_Nav_Menu {
 
     $classes = array_unique($classes);
 
-    return array_filter($classes, 'Sageextras\\Nav\\is_element_empty');
+    return array_filter($classes, function ($element) {
+      $element = trim($element);
+      return !empty($element);
+    });
   }
 }
 
@@ -117,14 +120,6 @@ function nav_menu_args($args = '') {
     $sagextras_nav_menu_args['walker'] = new NavWalker();
   }
   return array_merge($args, $sagextras_nav_menu_args);
-}
-
-/**
- * Utility functions.
- */
-function is_element_empty($element) {
-  $element = trim($element);
-  return !empty($element);
 }
 
 /**


### PR DESCRIPTION
In roots/soil pull request #95, is_element_empty was turned into closure. This is rather good thing to do.
